### PR TITLE
Spelling correction: CaluclateDrift vs CalculateDrift.

### DIFF
--- a/SlimLoRa.cpp
+++ b/SlimLoRa.cpp
@@ -355,7 +355,7 @@ uint8_t SlimLoRa::RfmRead(uint8_t address) {
 /**
  * Calculates the clock drift adjustment(+-5%).
  */
-uint32_t SlimLoRa::CaluclateDriftAdjustment(uint32_t delay, uint16_t micros_per_half_symbol) {
+uint32_t SlimLoRa::CalculateDriftAdjustment(uint32_t delay, uint16_t micros_per_half_symbol) {
     // Clock drift
     uint32_t drift = delay * 5 / 100;
     delay -= drift;
@@ -396,7 +396,7 @@ uint32_t SlimLoRa::CalculateRxDelay(uint8_t data_rate, uint32_t delay) {
     micros_per_half_symbol = pgm_read_word(&(kDRMicrosPerHalfSymbol[data_rate]));
     offset = CalculateRxWindowOffset(micros_per_half_symbol);
 
-    return CaluclateDriftAdjustment(delay + offset, micros_per_half_symbol);
+    return CalculateDriftAdjustment(delay + offset, micros_per_half_symbol);
 }
 
 /**

--- a/SlimLoRa.h
+++ b/SlimLoRa.h
@@ -200,7 +200,7 @@ class SlimLoRa {
     void RfmSendPacket(uint8_t *packet, uint8_t packet_length, uint8_t channel, uint8_t dri);
     void RfmWrite(uint8_t address, uint8_t data);
     uint8_t RfmRead(uint8_t address);
-    uint32_t CaluclateDriftAdjustment(uint32_t delay, uint16_t micros_per_half_symbol);
+    uint32_t CalculateDriftAdjustment(uint32_t delay, uint16_t micros_per_half_symbol);
     int32_t CalculateRxWindowOffset(int16_t micros_per_half_symbol);
     uint32_t CalculateRxDelay(uint8_t data_rate, uint32_t delay);
     bool CheckMic(uint8_t *cmic, uint8_t *rmic);


### PR DESCRIPTION
After reading one time the LoRaWAN-1.0.3 spec I try to understand your library, so I came across this insignificant spelling 'mistake'.

Thank you for your work.